### PR TITLE
fixed missing scales + refactored App hooks

### DIFF
--- a/src/containers/App/index.js
+++ b/src/containers/App/index.js
@@ -16,17 +16,19 @@ function App (props) {
    const [tonic, setTonic] = useState(DEFAULT_TONIC);
 
    // For scale dropdown, e.g. major, minor, mixolydian, etc.
-   const scaleNames = useMemo(
-      () => scaleDictionary().reduce(
-         (acc, curr) => {
-            acc.push(curr.name);
-            return acc;
-         }, []
-      ).sort()
-   );
+   const scaleNames = useMemo(() => {
+      const map = {};
+      scaleDictionary().forEach(s => {
+         map[s.name] = {};
+         s.aliases.forEach(a => {
+            map[a] = {};
+         });
+      });
+      return Object.keys(map).sort();
+   }, []);
 
    // For tonic selector, e.g. C5, Ab4, G1, etc.
-   const tonicList = useMemo(() => chromatic(RANGE_TUPLET));
+   const tonicList = useMemo(() => chromatic(RANGE_TUPLET), []);
 
    return (
       <Container>


### PR DESCRIPTION
@tonaljs/scale-dictionary has aliases that don't appear in the dictionary itself (natural minor for instance). I refactored the hook so that it includes those aliases and uses object keys to avoid duplicates. The use of object keys has the fortunate side-effect of being much faster than comparing strings. @tonaljs/scale can parse aliases. I also added empty dependency arrays in hooks that needed them.